### PR TITLE
Grove LCD RGB Backlight device support

### DIFF
--- a/grove/lcdrgbbacklight/README.md
+++ b/grove/lcdrgbbacklight/README.md
@@ -1,0 +1,16 @@
+#Grove - LCD RGB Backlight
+
+[![GoDoc](http://godoc.org/github.com/goiot/devices/grove/lcdgobacklight?status.png)](http://godoc.org/github.com/goiot/devices/grove/oled96x96)
+
+[Manufacturer info](http://www.seeedstudio.com/wiki/Grove_-_LCD_RGB_Backlight)
+
+This device is an i2c colorful RGB backlight display module with Grove compatible
+4pin I2C interface.
+This display supports scrolling as well as English and Japanese fonts plus custom characters using [CGRAM](http://www.8051projects.net/lcd-interfacing/lcd-custom-character.php).
+
+![Grove - LCD RGB Backlight](http://www.seeedstudio.com/wiki/images/thumb/0/03/Serial_LEC_RGB_Backlight_Lcd.jpg/500px-Serial_LEC_RGB_Backlight_Lcd.jpg)
+
+##Datasheets:
+
+* [LCD Datasheet](http://www.seeedstudio.com/wiki/images/0/03/JHD1214Y_YG_1.0.pdf)
+* [BackLight Datasheet](http://www.seeedstudio.com/wiki/images/1/1c/PCA9633.pdf)

--- a/grove/lcdrgbbacklight/characters.go
+++ b/grove/lcdrgbbacklight/characters.go
@@ -1,0 +1,26 @@
+package lcdrgbbacklight
+
+// CustomLCDChars is a map of CGRAM characters that can be loaded
+// into a LCD screen to display custom characters. Some LCD screens such
+// as the Grove screen (jhd1313m1) isn't loaded with latin 1 characters.
+// It's up to the developer to load the set up to 8 custom characters and
+// update the input text so the character is swapped by a byte reflecting
+// the position of the custom character to use.
+// See SetCustomChar
+var CustomLCDChars = map[string][8]byte{
+	"é":       [8]byte{130, 132, 142, 145, 159, 144, 142, 128},
+	"è":       [8]byte{136, 132, 142, 145, 159, 144, 142, 128},
+	"ê":       [8]byte{132, 138, 142, 145, 159, 144, 142, 128},
+	"à":       [8]byte{136, 134, 128, 142, 145, 147, 141, 128},
+	"â":       [8]byte{132, 138, 128, 142, 145, 147, 141, 128},
+	"á":       [8]byte{2, 4, 14, 1, 15, 17, 15, 0},
+	"î":       [8]byte{132, 138, 128, 140, 132, 132, 142, 128},
+	"í":       [8]byte{2, 4, 12, 4, 4, 4, 14, 0},
+	"û":       [8]byte{132, 138, 128, 145, 145, 147, 141, 128},
+	"ù":       [8]byte{136, 134, 128, 145, 145, 147, 141, 128},
+	"ñ":       [8]byte{14, 0, 22, 25, 17, 17, 17, 0},
+	"ó":       [8]byte{2, 4, 14, 17, 17, 17, 14, 0},
+	"heart":   [8]byte{0, 10, 31, 31, 31, 14, 4, 0},
+	"smiley":  [8]byte{0, 0, 10, 0, 0, 17, 14, 0},
+	"frowney": [8]byte{0, 0, 10, 0, 0, 0, 14, 17},
+}

--- a/grove/lcdrgbbacklight/examples/helloworld/main.go
+++ b/grove/lcdrgbbacklight/examples/helloworld/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"time"
+
+	"github.com/goiot/devices/grove/lcdrgbbacklight"
+	"golang.org/x/exp/io/i2c"
+)
+
+func main() {
+	display, err := lcdrgbbacklight.New(
+		&i2c.Devfs{
+			Dev:  "/dev/i2c-1",
+			Addr: lcdrgbbacklight.LCDAddress,
+		},
+		&i2c.Devfs{
+			Dev:  "/dev/i2c-1",
+			Addr: lcdrgbbacklight.RGBAddress,
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+	defer display.Close()
+
+	display.Write("Hello World!")
+	display.SetRGB(0, 255, 0)
+
+	time.Sleep(5 * time.Second)
+
+	display.Clear()
+	display.Home()
+	display.SetRGB(255, 124, 0)
+
+	display.SetCustomChar(0, lcdrgbbacklight.CustomLCDChars["smiley"])
+	display.Write("goodbye\nhave a nice day " + string(byte(0)))
+
+	ticker := time.NewTicker(time.Millisecond * 200)
+	go func() {
+		for _ = range ticker.C {
+			display.Scroll(false)
+		}
+	}()
+	time.Sleep(4 * time.Second)
+	ticker.Stop()
+}

--- a/grove/lcdrgbbacklight/lcdrgbbacklight.go
+++ b/grove/lcdrgbbacklight/lcdrgbbacklight.go
@@ -1,0 +1,177 @@
+// Package lcdrgbbacklight implements a driver for the Grove LCD RGB Backlight display.
+package lcdrgbbacklight
+
+import (
+	"fmt"
+	"time"
+
+	"golang.org/x/exp/io/i2c"
+	"golang.org/x/exp/io/i2c/driver"
+)
+
+// LCDRGBBacklight is a driver for the Jhd1313m1 LCD display which has two i2c addresses,
+// one belongs to a controller and the other controls solely the backlight.
+type LCDRGBBacklight struct {
+	LCD *i2c.Device
+	RGB *i2c.Device
+}
+
+// New connects to the lcd and rgb openers, connects and sets up.
+func New(lcd driver.Opener, rgb driver.Opener) (*LCDRGBBacklight, error) {
+	lcdD, err := i2c.Open(lcd)
+	if err != nil {
+		return nil, fmt.Errorf("LCD driver failed to connect - %v", err)
+	}
+
+	rgbD, err := i2c.Open(rgb)
+	if err != nil {
+		return nil, fmt.Errorf("RGB driver failed to connect - %v", err)
+	}
+
+	display := &LCDRGBBacklight{
+		LCD: lcdD,
+		RGB: rgbD,
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	if err := lcdD.Write([]byte{lcdCmd, lcdFunctionSet | lcd2Line}); err != nil {
+		return nil, fmt.Errorf("LCD failed to initialize (part 1) - %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	if err := lcdD.Write([]byte{lcdCmd, lcdDisplayControl | lcdDisplayOn}); err != nil {
+		return nil, fmt.Errorf("LCD failed to initialize (part 2) - %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	if err := display.Clear(); err != nil {
+		return nil, fmt.Errorf("display failed to clear - %v", err)
+	}
+
+	if err := lcdD.Write([]byte{lcdCmd, lcdEntryModeSet | lcdEntryLeft | lcdEntryShiftDecrement}); err != nil {
+		return nil, fmt.Errorf("failed to initialize (part 3) - %v", err)
+	}
+
+	// registry 0
+	if err := display.setReg(0x0, 0x1); err != nil {
+		return nil, fmt.Errorf("failed to set registry 0 - %v", err)
+	}
+
+	// registry 1
+	if err := display.setReg(0x1, 0x0); err != nil {
+		return nil, fmt.Errorf("failed to set registry 1 - %v", err)
+	}
+
+	// registry 8
+	if err := display.setReg(0x08, 0xAA); err != nil {
+		return nil, fmt.Errorf("failed to set registry 8 - %v", err)
+	}
+
+	if err := display.SetRGB(255, 255, 255); err != nil {
+		return nil, fmt.Errorf("failed to set registry 8 - %v", err)
+	}
+
+	return display, nil
+}
+
+// SetRGB sets the Red Green Blue value of backlit.
+func (d *LCDRGBBacklight) SetRGB(r, g, b int) error {
+	if err := d.setReg(regRed, byte(r)); err != nil {
+		return err
+	}
+	if err := d.setReg(regGreen, byte(g)); err != nil {
+		return err
+	}
+	return d.setReg(regBlue, byte(b))
+}
+
+// Clear clears the text on the lCD display.
+func (d *LCDRGBBacklight) Clear() error {
+	err := d.command([]byte{lcdClearDisplay})
+	return err
+}
+
+// Home sets the cursor to the origin position on the display.
+func (d *LCDRGBBacklight) Home() error {
+	err := d.command([]byte{lcdReturnHome})
+	// This wait fixes a race condition when calling home and clear back to back.
+	time.Sleep(2 * time.Millisecond)
+	return err
+}
+
+// Write displays the passed message on the screen.
+func (d *LCDRGBBacklight) Write(message string) error {
+	// This wait fixes an odd bug where the clear function doesn't always work properly.
+	time.Sleep(1 * time.Millisecond)
+	for _, val := range message {
+		if val == '\n' {
+			if err := d.SetPosition(16); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := d.LCD.Write([]byte{lcdData, byte(val)}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SetPosition sets the cursor and the data display to pos.
+// 0..15 are the positions in the first display line.
+// 16..32 are the positions in the second display line.
+func (d *LCDRGBBacklight) SetPosition(pos int) (err error) {
+	if pos < 0 || pos > 31 {
+		err = ErrInvalidPosition
+		return
+	}
+	offset := byte(pos)
+	if pos >= 16 {
+		offset -= 16
+		offset |= lcd2ndLineOffset
+	}
+	err = d.command([]byte{lcdSetDdramAddr | offset})
+	return
+}
+
+// Scroll scrolls the text on the display
+func (d *LCDRGBBacklight) Scroll(leftToRight bool) error {
+	if leftToRight {
+		return d.command([]byte{lcdCursorShift | lcdDisplayMove | lcdMoveLeft})
+	}
+
+	return d.command([]byte{lcdCursorShift | lcdDisplayMove | lcdMoveRight})
+}
+
+// CustomChar sets one of the 8 CGRAM locations with a custom character.
+// The custom character can be used by writing a byte of value 0 to 7.
+// When you are using LCD as 5x8 dots in function set then you can define a total of 8 user defined patterns
+// (1 Byte for each row and 8 rows for each pattern).
+// Use http://www.8051projects.net/lcd-interfacing/lcd-custom-character.php to create your own
+// characters.
+// To use a custom character, write byte value of the custom character position as a string after
+// having setup the custom character.
+func (d *LCDRGBBacklight) SetCustomChar(pos int, charMap [8]byte) error {
+	if pos > 7 {
+		return fmt.Errorf("can't set a custom character at a position greater than 7")
+	}
+	location := uint8(pos)
+	if err := d.command([]byte{lcdSetCgramAddr | (location << 3)}); err != nil {
+		return err
+	}
+
+	return d.LCD.Write(append([]byte{lcdData}, charMap[:]...))
+}
+
+// Close cleans up the connections
+func (d *LCDRGBBacklight) Close() error {
+	d.Clear()
+	d.SetRGB(0, 0, 0)
+	if err := d.LCD.Close(); err != nil {
+		return err
+	}
+	if err := d.RGB.Close(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/grove/lcdrgbbacklight/protocol.go
+++ b/grove/lcdrgbbacklight/protocol.go
@@ -1,0 +1,59 @@
+package lcdrgbbacklight
+
+import "errors"
+
+const (
+	LCDAddress = 0x3E
+	RGBAddress = 0x62
+)
+
+const (
+	regRed   = 0x04
+	regGreen = 0x03
+	regBlue  = 0x02
+
+	lcdClearDisplay        = 0x01
+	lcdReturnHome          = 0x02
+	lcdEntryModeSet        = 0x04
+	lcdDisplayControl      = 0x08
+	lcdCursorShift         = 0x10
+	lcdFunctionSet         = 0x20
+	lcdSetCgramAddr        = 0x40
+	lcdSetDdramAddr        = 0x80
+	lcdEntryRight          = 0x00
+	lcdEntryLeft           = 0x02
+	lcdEntryShiftIncrement = 0x01
+	lcdEntryShiftDecrement = 0x00
+	lcdDisplayOn           = 0x04
+	lcdDisplayOff          = 0x00
+	lcdCursorOn            = 0x02
+	lcdCursorOff           = 0x00
+	lcdBlinkOn             = 0x01
+	lcdBlinkOff            = 0x00
+	lcdDisplayMove         = 0x08
+	lcdCursorMove          = 0x00
+	lcdMoveRight           = 0x04
+	lcdMoveLeft            = 0x00
+	lcd2Line               = 0x08
+	lcdCmd                 = 0x80
+	lcdData                = 0x40
+
+	lcd2ndLineOffset = 0x40
+)
+
+var (
+	ErrInvalidPosition = errors.New("Invalid position value")
+)
+
+func (d *LCDRGBBacklight) setReg(cmd byte, data byte) error {
+	// TODO(mattetti): reuse a buffer instead of reallocating
+	if err := d.RGB.Write([]byte{cmd, data}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// TODO(mattetti): change the arg to be variadic
+func (d *LCDRGBBacklight) command(buf []byte) error {
+	return d.LCD.Write(append([]byte{lcdCmd}, buf...))
+}

--- a/grove/oled96x96/oled96x96.go
+++ b/grove/oled96x96/oled96x96.go
@@ -17,7 +17,7 @@ type OLED96x96 struct {
 	grayL  byte
 }
 
-// New connects to the passed driver, connects and sets it up.
+// New connects to the passed driver, connects and sets up.
 func New(o driver.Opener) (*OLED96x96, error) {
 	// TODO(mattetti): switch to `o.Open(Address)` when the exp/io API updated.
 	device, err := i2c.Open(o)


### PR DESCRIPTION
This is a pretty complete implementation of the Grove LCD device, some of the code could be cleaned up, and the allocation could be reduced. That said I think it's good to merge as is.

Something interesting to notice is that we have to pass 2 devices (one for each address) when this is really a device concern and not a user's.

/cc @rakyll