### PR TITLE
Travis-CI: make sure we always use the latest version of exp/io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: go
 go:
   - 1.6
   - tip
+
+install:
+  - go get -u golang.org/x/exp/io/...


### PR DESCRIPTION
@rakyll I believe that if we don't setup travis to update the exp/io packages, we won't get the latest versions and therefore won't notice when upstream changes break our device builds. I might be wrong tho.